### PR TITLE
Changing Username for Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This R package provides a DBI client for the ClickHouse database
 * the latest development version from github with
 
     ```R
-    devtools::install_github("hannesmuehleisen/clickhouse-r")
+    devtools::install_github("hannes/clickhouse-r")
     ```
 
-If you encounter a bug, please file a minimal reproducible example on [github](https://github.com/hannesmuehleisen/clickhouse-r/issues).
+If you encounter a bug, please file a minimal reproducible example on [github](https://github.com/hannes/clickhouse-r/issues).
 
 ## Usage
 


### PR DESCRIPTION
In README,

username was pointing to hannesmuehleisen

devtools::install_github("hannesmuehleisen/clickhouse-r")

have changed it to hannes to avoid confusion.

devtools::install_github("hannes/clickhouse-r")